### PR TITLE
pass aws_region to EKS for cluster-autoscaler

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -15,6 +15,7 @@ module "mlops-architecture-eks" {
 
   cluster_name = var.cluster_name
   map_users = var.additional_aws_users
+  aws_region = var.aws_region
 }
 
 


### PR DESCRIPTION
Passing aws_region to EKS repo. so that cluster-autoscaler can use.