### PR TITLE
use local backend by default

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  backend "s3" {
+  backend "local" {
   }
 }
 


### PR DESCRIPTION
This reverts the terraform backend to be local by default so that users don't have to set up and configure S3 manually in order to use this repository.