### PR TITLE
add account recovery settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.2.0
+
+### Features
+- Support password recovery using SMTP
+
 ## 0.1.0
 
 ### Features

--- a/main.tf
+++ b/main.tf
@@ -71,6 +71,10 @@ module "mlops-architecture" {
 
   aws = true
   enable_registration_page = var.enable_registration_page
+  enable_password_recovery = var.enable_password_recovery
+  enable_verification = var.enable_verification
+  smtp_connection_uri = var.smtp_connection_uri
+  smtp_from_address = var.smtp_from_address
   tls_certificate_arn = var.tls_certificate_arn
 
   access_rules_path = var.access_rules_path

--- a/variables.tf
+++ b/variables.tf
@@ -84,6 +84,30 @@ variable "enable_registration_page" {
   default = true
 }
 
+variable "smtp_connection_uri" {
+  description = "SMTP Connection for Ory"
+  type = string
+  default = "smtp://omigamibot%40gmail.com:omigamidevbot2021@smtp.gmail.com:587"
+}
+
+variable "smtp_from_address" {
+  description = "Email address for outgoing mails from Ory"
+  type = string
+  default = "omigamibot@gmail.com"
+}
+
+variable "enable_password_recovery" {
+  description = "Bool to set to enable password recovery using emails"
+  type = bool
+  default = false
+}
+
+variable "enable_verification" {
+  description = "Bool to set to enable account registration confirmation using emails"
+  type = bool
+  default = false
+}
+
 variable "eks_worker_groups" {
   description = "Definition of AWS worker groups to be utilized."
   type = list(object({


### PR DESCRIPTION
- Add option to send password recovery using emails.
- SMTP information can be set using `smtp_connection_uri` and `smtp_from_address` vars
